### PR TITLE
楽天トラベル空室検索APIのレスポンス構造に合わせて実装を更新

### DIFF
--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -53,7 +53,7 @@ describe('RakutenHotelServer', () => {
     // Serverコンストラクタが正しいパラメータで呼ばれたことを確認
     expect(Server).toHaveBeenCalledWith(
       {
-        name: 'rakuten-hotel-mcp',
+        name: 'rakuten-hotel',
         version: '0.1.0',
       },
       {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ class RakutenHotelServer {
     // MCPサーバーの初期化
     this.server = new Server(
       {
-        name: 'rakuten-hotel-mcp',
+        name: 'rakuten-hotel',
         version: '0.1.0',
       },
       {
@@ -37,6 +37,9 @@ class RakutenHotelServer {
 
     // エラーハンドリング
     this.server.onerror = (error) => console.error('[MCP Error]', error);
+    
+    // デバッグログを追加
+    process.env.DEBUG = 'mcp:*';
     process.on('SIGINT', async () => {
       await this.server.close();
       process.exit(0);
@@ -79,7 +82,7 @@ class RakutenHotelServer {
   }
 
   async run() {
-    const transport = new StdioServerTransport();
+    const transport = new StdioServerTransport(process.stdin, process.stdout);
     await this.server.connect(transport);
     console.error('楽天ホテルMCPサーバーが起動しました');
   }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -37,7 +37,7 @@ class RakutenHotelServer {
 
     // エラーハンドリング
     this.server.onerror = (error) => console.error('[MCP Error]', error);
-    
+
     process.on('SIGINT', async () => {
       await this.server.close();
       process.exit(0);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -38,8 +38,6 @@ class RakutenHotelServer {
     // エラーハンドリング
     this.server.onerror = (error) => console.error('[MCP Error]', error);
     
-    // デバッグログを追加
-    process.env.DEBUG = 'mcp:*';
     process.on('SIGINT', async () => {
       await this.server.close();
       process.exit(0);

--- a/src/server/tools/getHotelsTool.test.ts
+++ b/src/server/tools/getHotelsTool.test.ts
@@ -19,160 +19,160 @@ const mockApiResponseData: RakutenApiResponse = {
     pageCount: 1,
     page: 1,
     first: 1,
-    last: 3
+    last: 3,
   },
   hotels: [
     [
       {
         hotelBasicInfo: {
           hotelNo: 100001,
-          hotelName: "テストホテル東京",
-          hotelInformationUrl: "https://example.com/hotel/100001",
-          planListUrl: "https://example.com/hotel/100001/plans",
-          dpPlanListUrl: "https://example.com/hotel/100001/dp_plans",
-          reviewUrl: "https://example.com/hotel/100001/reviews",
-          hotelKanaName: "てすとほてるとうきょう",
-          hotelSpecial: "東京駅から徒歩5分。快適な客室と充実した設備が魅力です。",
+          hotelName: 'テストホテル東京',
+          hotelInformationUrl: 'https://example.com/hotel/100001',
+          planListUrl: 'https://example.com/hotel/100001/plans',
+          dpPlanListUrl: 'https://example.com/hotel/100001/dp_plans',
+          reviewUrl: 'https://example.com/hotel/100001/reviews',
+          hotelKanaName: 'てすとほてるとうきょう',
+          hotelSpecial: '東京駅から徒歩5分。快適な客室と充実した設備が魅力です。',
           hotelMinCharge: 8000,
           latitude: 35.67922715,
           longitude: 139.7698432,
-          postalCode: "100-0001",
-          address1: "東京都",
-          address2: "千代田区1-1-1",
-          telephoneNo: "03-1234-5678",
-          faxNo: "03-1234-5679",
-          access: "東京駅より徒歩5分",
-          parkingInformation: "有料駐車場あり",
-          nearestStation: "東京",
-          hotelImageUrl: "https://example.com/images/hotel/100001.jpg",
-          hotelThumbnailUrl: "https://example.com/images/hotel/thumb/100001.jpg",
-          roomImageUrl: "https://example.com/images/room/100001.jpg",
-          roomThumbnailUrl: "https://example.com/images/room/thumb/100001.jpg",
-          hotelMapImageUrl: "https://example.com/images/map/100001.gif",
+          postalCode: '100-0001',
+          address1: '東京都',
+          address2: '千代田区1-1-1',
+          telephoneNo: '03-1234-5678',
+          faxNo: '03-1234-5679',
+          access: '東京駅より徒歩5分',
+          parkingInformation: '有料駐車場あり',
+          nearestStation: '東京',
+          hotelImageUrl: 'https://example.com/images/hotel/100001.jpg',
+          hotelThumbnailUrl: 'https://example.com/images/hotel/thumb/100001.jpg',
+          roomImageUrl: 'https://example.com/images/room/100001.jpg',
+          roomThumbnailUrl: 'https://example.com/images/room/thumb/100001.jpg',
+          hotelMapImageUrl: 'https://example.com/images/map/100001.gif',
           reviewCount: 1000,
           reviewAverage: 4.5,
-          userReview: "とても快適に過ごせました。スタッフの対応も良く、また利用したいです。"
-        }
+          userReview: 'とても快適に過ごせました。スタッフの対応も良く、また利用したいです。',
+        },
       },
       {
         roomInfo: [
           {
             roomBasicInfo: {
-              roomClass: "sgl",
-              roomName: "シングルルーム",
+              roomClass: 'sgl',
+              roomName: 'シングルルーム',
               planId: 5000001,
-              planName: "【素泊まり】シンプルステイプラン",
+              planName: '【素泊まり】シンプルステイプラン',
               pointRate: 1,
               withDinnerFlag: 0,
               dinnerSelectFlag: 0,
               withBreakfastFlag: 0,
               breakfastSelectFlag: 0,
-              payment: "1",
-              reserveUrl: "https://example.com/reserve/100001/sgl/5000001",
-              salesformFlag: 0
-            }
+              payment: '1',
+              reserveUrl: 'https://example.com/reserve/100001/sgl/5000001',
+              salesformFlag: 0,
+            },
           },
           {
             dailyCharge: {
-              stayDate: "2023-12-01",
+              stayDate: '2023-12-01',
               rakutenCharge: 10000,
               total: 10000,
-              chargeFlag: 0
-            }
-          }
-        ]
+              chargeFlag: 0,
+            },
+          },
+        ],
       },
       {
         roomInfo: [
           {
             roomBasicInfo: {
-              roomClass: "dbl",
-              roomName: "ダブルルーム",
+              roomClass: 'dbl',
+              roomName: 'ダブルルーム',
               planId: 5000002,
-              planName: "【素泊まり】カップルプラン",
+              planName: '【素泊まり】カップルプラン',
               pointRate: 1,
               withDinnerFlag: 0,
               dinnerSelectFlag: 0,
               withBreakfastFlag: 0,
               breakfastSelectFlag: 0,
-              payment: "1",
-              reserveUrl: "https://example.com/reserve/100001/dbl/5000002",
-              salesformFlag: 0
-            }
+              payment: '1',
+              reserveUrl: 'https://example.com/reserve/100001/dbl/5000002',
+              salesformFlag: 0,
+            },
           },
           {
             dailyCharge: {
-              stayDate: "2023-12-01",
+              stayDate: '2023-12-01',
               rakutenCharge: 15000,
               total: 15000,
-              chargeFlag: 0
-            }
-          }
-        ]
-      }
+              chargeFlag: 0,
+            },
+          },
+        ],
+      },
     ],
     [
       {
         hotelBasicInfo: {
           hotelNo: 100002,
-          hotelName: "テストホテル大阪",
-          hotelInformationUrl: "https://example.com/hotel/100002",
-          planListUrl: "https://example.com/hotel/100002/plans",
-          dpPlanListUrl: "https://example.com/hotel/100002/dp_plans",
-          reviewUrl: "https://example.com/hotel/100002/reviews",
-          hotelKanaName: "てすとほてるおおさか",
-          hotelSpecial: "大阪駅から徒歩3分。ビジネスにも観光にも便利な立地です。",
+          hotelName: 'テストホテル大阪',
+          hotelInformationUrl: 'https://example.com/hotel/100002',
+          planListUrl: 'https://example.com/hotel/100002/plans',
+          dpPlanListUrl: 'https://example.com/hotel/100002/dp_plans',
+          reviewUrl: 'https://example.com/hotel/100002/reviews',
+          hotelKanaName: 'てすとほてるおおさか',
+          hotelSpecial: '大阪駅から徒歩3分。ビジネスにも観光にも便利な立地です。',
           hotelMinCharge: 7000,
           latitude: 34.70283,
           longitude: 135.49609,
-          postalCode: "530-0001",
-          address1: "大阪府",
-          address2: "大阪市北区1-1-1",
-          telephoneNo: "06-1234-5678",
-          faxNo: "06-1234-5679",
-          access: "大阪駅より徒歩3分",
-          parkingInformation: "提携駐車場あり（有料）",
-          nearestStation: "大阪",
-          hotelImageUrl: "https://example.com/images/hotel/100002.jpg",
-          hotelThumbnailUrl: "https://example.com/images/hotel/thumb/100002.jpg",
-          roomImageUrl: "https://example.com/images/room/100002.jpg",
-          roomThumbnailUrl: "https://example.com/images/room/thumb/100002.jpg",
-          hotelMapImageUrl: "https://example.com/images/map/100002.gif",
+          postalCode: '530-0001',
+          address1: '大阪府',
+          address2: '大阪市北区1-1-1',
+          telephoneNo: '06-1234-5678',
+          faxNo: '06-1234-5679',
+          access: '大阪駅より徒歩3分',
+          parkingInformation: '提携駐車場あり（有料）',
+          nearestStation: '大阪',
+          hotelImageUrl: 'https://example.com/images/hotel/100002.jpg',
+          hotelThumbnailUrl: 'https://example.com/images/hotel/thumb/100002.jpg',
+          roomImageUrl: 'https://example.com/images/room/100002.jpg',
+          roomThumbnailUrl: 'https://example.com/images/room/thumb/100002.jpg',
+          hotelMapImageUrl: 'https://example.com/images/map/100002.gif',
           reviewCount: 800,
           reviewAverage: 4.2,
-          userReview: "立地が良く、観光に便利でした。部屋も清潔で快適に過ごせました。"
-        }
+          userReview: '立地が良く、観光に便利でした。部屋も清潔で快適に過ごせました。',
+        },
       },
       {
         roomInfo: [
           {
             roomBasicInfo: {
-              roomClass: "sgl",
-              roomName: "シングルルーム",
+              roomClass: 'sgl',
+              roomName: 'シングルルーム',
               planId: 5000003,
-              planName: "【素泊まり】ビジネスプラン",
+              planName: '【素泊まり】ビジネスプラン',
               pointRate: 1,
               withDinnerFlag: 0,
               dinnerSelectFlag: 0,
               withBreakfastFlag: 0,
               breakfastSelectFlag: 0,
-              payment: "1",
-              reserveUrl: "https://example.com/reserve/100002/sgl/5000003",
-              salesformFlag: 0
-            }
+              payment: '1',
+              reserveUrl: 'https://example.com/reserve/100002/sgl/5000003',
+              salesformFlag: 0,
+            },
           },
           {
             dailyCharge: {
-              stayDate: "2023-12-01",
+              stayDate: '2023-12-01',
               rakutenCharge: 9000,
               total: 9000,
-              chargeFlag: 0
-            }
-          }
-        ]
-      }
-    ]
-  ]
+              chargeFlag: 0,
+            },
+          },
+        ],
+      },
+    ],
+  ],
 };
 
 describe('getHotelsTool', () => {
@@ -182,7 +182,7 @@ describe('getHotelsTool', () => {
 
   it('正常に動作する場合、適切なパラメータでAPIを呼び出し結果を返すこと', async () => {
     const mockApiResponse = {
-      data: mockApiResponseData
+      data: mockApiResponseData,
     };
 
     mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
@@ -215,16 +215,16 @@ describe('getHotelsTool', () => {
     expect(result).toHaveProperty('result');
     expect(result.result).toHaveProperty('hotels');
     expect(result.result).toHaveProperty('pagingInfo');
-    
+
     // ホテル数の確認
     expect(result.result?.hotels.length).toBe(2);
-    
+
     // 最初のホテルの基本情報を確認
     const firstHotel = result.result?.hotels[0];
     expect(firstHotel).toHaveProperty('hotelBasicInfo');
     expect(firstHotel).toHaveProperty('roomInfoList');
     expect(firstHotel?.hotelBasicInfo.hotelName).toBe('テストホテル東京');
-    
+
     // 部屋情報の確認
     expect(firstHotel?.roomInfoList.length).toBeGreaterThan(0);
     expect(firstHotel?.roomInfoList[0]).toHaveProperty('roomBasicInfo');

--- a/src/server/tools/getHotelsTool.test.ts
+++ b/src/server/tools/getHotelsTool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import { getHotelsTool } from './getHotelsTool';
+import { RakutenApiResponse } from '../../types/index.js';
 
 vi.mock('axios');
 interface MockedAxios {
@@ -11,6 +12,169 @@ const mockedAxios = axios as unknown as MockedAxios;
 vi.stubEnv('APPLICATION_ID', 'test-application-id');
 vi.stubEnv('AFFILIATE_ID', 'test-affiliate-id');
 
+// 実際のAPIレスポンスに基づいたモックデータ
+const mockApiResponseData: RakutenApiResponse = {
+  pagingInfo: {
+    recordCount: 3,
+    pageCount: 1,
+    page: 1,
+    first: 1,
+    last: 3
+  },
+  hotels: [
+    [
+      {
+        hotelBasicInfo: {
+          hotelNo: 100001,
+          hotelName: "テストホテル東京",
+          hotelInformationUrl: "https://example.com/hotel/100001",
+          planListUrl: "https://example.com/hotel/100001/plans",
+          dpPlanListUrl: "https://example.com/hotel/100001/dp_plans",
+          reviewUrl: "https://example.com/hotel/100001/reviews",
+          hotelKanaName: "てすとほてるとうきょう",
+          hotelSpecial: "東京駅から徒歩5分。快適な客室と充実した設備が魅力です。",
+          hotelMinCharge: 8000,
+          latitude: 35.67922715,
+          longitude: 139.7698432,
+          postalCode: "100-0001",
+          address1: "東京都",
+          address2: "千代田区1-1-1",
+          telephoneNo: "03-1234-5678",
+          faxNo: "03-1234-5679",
+          access: "東京駅より徒歩5分",
+          parkingInformation: "有料駐車場あり",
+          nearestStation: "東京",
+          hotelImageUrl: "https://example.com/images/hotel/100001.jpg",
+          hotelThumbnailUrl: "https://example.com/images/hotel/thumb/100001.jpg",
+          roomImageUrl: "https://example.com/images/room/100001.jpg",
+          roomThumbnailUrl: "https://example.com/images/room/thumb/100001.jpg",
+          hotelMapImageUrl: "https://example.com/images/map/100001.gif",
+          reviewCount: 1000,
+          reviewAverage: 4.5,
+          userReview: "とても快適に過ごせました。スタッフの対応も良く、また利用したいです。"
+        }
+      },
+      {
+        roomInfo: [
+          {
+            roomBasicInfo: {
+              roomClass: "sgl",
+              roomName: "シングルルーム",
+              planId: 5000001,
+              planName: "【素泊まり】シンプルステイプラン",
+              pointRate: 1,
+              withDinnerFlag: 0,
+              dinnerSelectFlag: 0,
+              withBreakfastFlag: 0,
+              breakfastSelectFlag: 0,
+              payment: "1",
+              reserveUrl: "https://example.com/reserve/100001/sgl/5000001",
+              salesformFlag: 0
+            }
+          },
+          {
+            dailyCharge: {
+              stayDate: "2023-12-01",
+              rakutenCharge: 10000,
+              total: 10000,
+              chargeFlag: 0
+            }
+          }
+        ]
+      },
+      {
+        roomInfo: [
+          {
+            roomBasicInfo: {
+              roomClass: "dbl",
+              roomName: "ダブルルーム",
+              planId: 5000002,
+              planName: "【素泊まり】カップルプラン",
+              pointRate: 1,
+              withDinnerFlag: 0,
+              dinnerSelectFlag: 0,
+              withBreakfastFlag: 0,
+              breakfastSelectFlag: 0,
+              payment: "1",
+              reserveUrl: "https://example.com/reserve/100001/dbl/5000002",
+              salesformFlag: 0
+            }
+          },
+          {
+            dailyCharge: {
+              stayDate: "2023-12-01",
+              rakutenCharge: 15000,
+              total: 15000,
+              chargeFlag: 0
+            }
+          }
+        ]
+      }
+    ],
+    [
+      {
+        hotelBasicInfo: {
+          hotelNo: 100002,
+          hotelName: "テストホテル大阪",
+          hotelInformationUrl: "https://example.com/hotel/100002",
+          planListUrl: "https://example.com/hotel/100002/plans",
+          dpPlanListUrl: "https://example.com/hotel/100002/dp_plans",
+          reviewUrl: "https://example.com/hotel/100002/reviews",
+          hotelKanaName: "てすとほてるおおさか",
+          hotelSpecial: "大阪駅から徒歩3分。ビジネスにも観光にも便利な立地です。",
+          hotelMinCharge: 7000,
+          latitude: 34.70283,
+          longitude: 135.49609,
+          postalCode: "530-0001",
+          address1: "大阪府",
+          address2: "大阪市北区1-1-1",
+          telephoneNo: "06-1234-5678",
+          faxNo: "06-1234-5679",
+          access: "大阪駅より徒歩3分",
+          parkingInformation: "提携駐車場あり（有料）",
+          nearestStation: "大阪",
+          hotelImageUrl: "https://example.com/images/hotel/100002.jpg",
+          hotelThumbnailUrl: "https://example.com/images/hotel/thumb/100002.jpg",
+          roomImageUrl: "https://example.com/images/room/100002.jpg",
+          roomThumbnailUrl: "https://example.com/images/room/thumb/100002.jpg",
+          hotelMapImageUrl: "https://example.com/images/map/100002.gif",
+          reviewCount: 800,
+          reviewAverage: 4.2,
+          userReview: "立地が良く、観光に便利でした。部屋も清潔で快適に過ごせました。"
+        }
+      },
+      {
+        roomInfo: [
+          {
+            roomBasicInfo: {
+              roomClass: "sgl",
+              roomName: "シングルルーム",
+              planId: 5000003,
+              planName: "【素泊まり】ビジネスプラン",
+              pointRate: 1,
+              withDinnerFlag: 0,
+              dinnerSelectFlag: 0,
+              withBreakfastFlag: 0,
+              breakfastSelectFlag: 0,
+              payment: "1",
+              reserveUrl: "https://example.com/reserve/100002/sgl/5000003",
+              salesformFlag: 0
+            }
+          },
+          {
+            dailyCharge: {
+              stayDate: "2023-12-01",
+              rakutenCharge: 9000,
+              total: 9000,
+              chargeFlag: 0
+            }
+          }
+        ]
+      }
+    ]
+  ]
+};
+
 describe('getHotelsTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -18,37 +182,7 @@ describe('getHotelsTool', () => {
 
   it('正常に動作する場合、適切なパラメータでAPIを呼び出し結果を返すこと', async () => {
     const mockApiResponse = {
-      data: {
-        pagingInfo: {
-          recordCount: 1,
-          pageCount: 1,
-          page: 1,
-          first: 1,
-          last: 1,
-        },
-        hotels: [
-          {
-            hotel: [
-              {
-                hotelBasicInfo: {
-                  hotelNo: 123456,
-                  hotelName: 'テストホテル',
-                  hotelInformationUrl: 'https://example.com/hotel',
-                  hotelMinCharge: 10000,
-                  address1: '東京都',
-                  address2: '新宿区',
-                  telephoneNo: '03-1234-5678',
-                  access: '新宿駅から徒歩5分',
-                  hotelImageUrl: 'https://example.com/image.jpg',
-                  reviewCount: 100,
-                  reviewAverage: 4.5,
-                  hotelSpecial: 'テスト特徴',
-                },
-              },
-            ],
-          },
-        ],
-      },
+      data: mockApiResponseData
     };
 
     mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
@@ -77,26 +211,23 @@ describe('getHotelsTool', () => {
       })
     );
 
-    expect(result).toEqual({
-      result: {
-        hotels: [
-          {
-            hotelNo: 123456,
-            hotelName: 'テストホテル',
-            hotelInformationUrl: 'https://example.com/hotel',
-            hotelMinCharge: 10000,
-            address1: '東京都',
-            address2: '新宿区',
-            telephoneNo: '03-1234-5678',
-            access: '新宿駅から徒歩5分',
-            hotelImageUrl: 'https://example.com/image.jpg',
-            reviewCount: 100,
-            reviewAverage: 4.5,
-            hotelSpecial: 'テスト特徴',
-          },
-        ],
-      },
-    });
+    // 期待される結果の構造を確認
+    expect(result).toHaveProperty('result');
+    expect(result.result).toHaveProperty('hotels');
+    expect(result.result).toHaveProperty('pagingInfo');
+    
+    // ホテル数の確認
+    expect(result.result?.hotels.length).toBe(2);
+    
+    // 最初のホテルの基本情報を確認
+    const firstHotel = result.result?.hotels[0];
+    expect(firstHotel).toHaveProperty('hotelBasicInfo');
+    expect(firstHotel).toHaveProperty('roomInfoList');
+    expect(firstHotel?.hotelBasicInfo.hotelName).toBe('テストホテル東京');
+    
+    // 部屋情報の確認
+    expect(firstHotel?.roomInfoList.length).toBeGreaterThan(0);
+    expect(firstHotel?.roomInfoList[0]).toHaveProperty('roomBasicInfo');
   });
 
   it('入力パラメータにlatitude、longitude、radiusKmが指定されている場合、それらを使用すること', async () => {

--- a/src/server/tools/getHotelsTool.ts
+++ b/src/server/tools/getHotelsTool.ts
@@ -182,9 +182,6 @@ function buildRequestParams(
 function formatResponse(data: RakutenApiResponse): HotelsResponse {
   const hotels: Hotel[] = [];
 
-  // デバッグログ
-  console.error('API Response:', JSON.stringify(data, null, 2));
-
   if (data.hotels && Array.isArray(data.hotels)) {
     data.hotels.forEach((hotelGroup) => {
       // hotelGroupは配列
@@ -215,9 +212,6 @@ function formatResponse(data: RakutenApiResponse): HotelsResponse {
       }
     });
   }
-
-  // デバッグログ
-  console.error('Formatted Response:', JSON.stringify({ hotels, pagingInfo: data.pagingInfo }, null, 2));
   
   return { 
     hotels,

--- a/src/server/tools/getHotelsTool.ts
+++ b/src/server/tools/getHotelsTool.ts
@@ -1,11 +1,11 @@
 import axios from 'axios';
-import { 
-  HotelQueryParams, 
-  HotelsResponse, 
-  Hotel, 
-  RakutenApiResponse, 
-  RoomInfo, 
-  HotelBasicInfo 
+import {
+  HotelQueryParams,
+  HotelsResponse,
+  Hotel,
+  RakutenApiResponse,
+  RoomInfo,
+  HotelBasicInfo,
 } from '../../types/index.js';
 
 // 戻り値の型を明示的に定義
@@ -195,7 +195,7 @@ function formatResponse(data: RakutenApiResponse): HotelsResponse {
           if (item.hotelBasicInfo) {
             hotelBasicInfo = item.hotelBasicInfo;
           }
-          
+
           // 部屋情報の処理
           if (item.roomInfo && Array.isArray(item.roomInfo)) {
             roomInfoList.push(...item.roomInfo);
@@ -206,16 +206,16 @@ function formatResponse(data: RakutenApiResponse): HotelsResponse {
         if (hotelBasicInfo) {
           hotels.push({
             hotelBasicInfo,
-            roomInfoList
+            roomInfoList,
           });
         }
       }
     });
   }
-  
-  return { 
+
+  return {
     hotels,
-    pagingInfo: data.pagingInfo
+    pagingInfo: data.pagingInfo,
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,10 +82,12 @@ export interface RakutenApiResponse {
     first: number; // 最初
     last: number; // 最後
   };
-  hotels: Array<Array<{
-    hotelBasicInfo?: HotelBasicInfo; // ホテル基本情報
-    roomInfo?: RoomInfo[]; // 部屋情報
-  }>>;
+  hotels: Array<
+    Array<{
+      hotelBasicInfo?: HotelBasicInfo; // ホテル基本情報
+      roomInfo?: RoomInfo[]; // 部屋情報
+    }>
+  >;
 }
 
 // ホテル検索結果レスポンス

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,22 +6,91 @@ export interface HotelQueryParams {
   radiusKm?: number;
 }
 
-export interface Hotel {
+// ホテルの基本情報
+export interface HotelBasicInfo {
   hotelNo: number; // 施設番号
   hotelName: string; // 施設名称
   hotelInformationUrl: string; // 施設情報ページURL
+  planListUrl: string; // プラン一覧ページURL
+  dpPlanListUrl: string; // 宿泊プラン一覧ページURL
+  reviewUrl: string; // レビューページURL
+  hotelKanaName: string; // 施設名称（カナ）
+  hotelSpecial: string; // 施設特色
   hotelMinCharge: number; // 最安料金
+  latitude: number; // 緯度
+  longitude: number; // 経度
+  postalCode: string; // 郵便番号
   address1: string; // 住所1
   address2: string; // 住所2
   telephoneNo: string; // 施設電話番号
+  faxNo: string; // 施設FAX番号
   access: string; // 施設へのアクセス
-  hotelImageUrl?: string; // 施設画像URL
-  reviewCount?: number; // 投稿件数
-  reviewAverage?: number; // 総合評価
-  hotelSpecial?: string; // 施設特色
+  parkingInformation: string; // 駐車場情報
+  nearestStation: string; // 最寄駅
+  hotelImageUrl: string; // 施設画像URL
+  hotelThumbnailUrl: string; // 施設サムネイルURL
+  roomImageUrl: string | null; // 部屋画像URL
+  roomThumbnailUrl: string | null; // 部屋サムネイルURL
+  hotelMapImageUrl: string; // 施設マップ画像URL
+  reviewCount: number; // 投稿件数
+  reviewAverage: number; // 総合評価
+  userReview: string; // ユーザーレビュー
 }
 
+// 部屋の基本情報
+export interface RoomBasicInfo {
+  roomClass: string; // 部屋クラス
+  roomName: string; // 部屋名称
+  planId: number; // プランID
+  planName: string; // プラン名称
+  pointRate: number; // ポイント率
+  withDinnerFlag: number; // 夕食フラグ
+  dinnerSelectFlag: number; // 夕食選択フラグ
+  withBreakfastFlag: number; // 朝食フラグ
+  breakfastSelectFlag: number; // 朝食選択フラグ
+  payment: string; // 支払い方法
+  reserveUrl: string; // 予約URL
+  salesformFlag: number; // 販売形態フラグ
+}
+
+// 日別料金情報
+export interface DailyCharge {
+  stayDate: string; // 宿泊日
+  rakutenCharge: number; // 楽天料金
+  total: number; // 合計
+  chargeFlag: number; // 料金フラグ
+}
+
+// 部屋情報
+export interface RoomInfo {
+  roomBasicInfo?: RoomBasicInfo; // 部屋基本情報
+  dailyCharge?: DailyCharge; // 日別料金情報
+}
+
+// ホテル情報（基本情報と部屋情報を含む）
+export interface Hotel {
+  hotelBasicInfo: HotelBasicInfo; // ホテル基本情報
+  roomInfoList: RoomInfo[]; // 部屋情報リスト
+}
+
+// 楽天APIレスポンス
 export interface RakutenApiResponse {
+  pagingInfo: {
+    recordCount: number; // レコード数
+    pageCount: number; // ページ数
+    page: number; // ページ
+    first: number; // 最初
+    last: number; // 最後
+  };
+  hotels: Array<Array<{
+    hotelBasicInfo?: HotelBasicInfo; // ホテル基本情報
+    roomInfo?: RoomInfo[]; // 部屋情報
+  }>>;
+}
+
+// ホテル検索結果レスポンス
+export interface HotelsResponse {
+  hotels: Hotel[];
   pagingInfo: {
     recordCount: number;
     pageCount: number;
@@ -29,26 +98,4 @@ export interface RakutenApiResponse {
     first: number;
     last: number;
   };
-  hotels?: {
-    hotel: {
-      hotelBasicInfo: {
-        hotelNo: number;
-        hotelName: string;
-        hotelInformationUrl: string;
-        hotelMinCharge: number;
-        address1: string;
-        address2: string;
-        telephoneNo: string;
-        access: string;
-        hotelImageUrl?: string;
-        reviewCount?: number;
-        reviewAverage?: number;
-        hotelSpecial?: string;
-      };
-    }[];
-  }[];
-}
-
-export interface HotelsResponse {
-  hotels: Hotel[];
 }


### PR DESCRIPTION
# 変更内容

## 型定義の更新
- \RakutenApiResponse\の型定義を実際のAPIレスポンス構造に合わせました
- ホテル基本情報(\HotelBasicInfo\)と部屋情報(\RoomInfo\, \RoomBasicInfo\, \DailyCharge\)の型を追加
- \Hotel\インターフェースを更新し、ホテル基本情報と部屋情報リストを含む構造に変更
- \HotelsResponse\に\pagingInfo\を追加

## データ処理ロジックの更新
- \ormatResponse\関数を修正し、APIレスポンスから正しくデータを抽出するように変更
- ホテルグループから基本情報と部屋情報を取得する処理を実装
- ページング情報をレスポンスに含めるように修正

## テストの更新
- モックデータを実際のAPIレスポンス構造に合わせて更新
- テストケースを新しい型定義に対応するよう修正
- 提供されたAPIレスポンスデータをマスキングしてテスト用モックデータとして使用

## その他の変更
- サーバー名を\akuten-hotel-mcp\から\akuten-hotel\に変更
- テストの期待値を実装に合わせて更新
- 不要なデバッグ用コードを削除

# テスト結果
全てのテストが正常に通過することを確認しました。