### PR TITLE
ホテル検索機能の改善

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,9 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.9.0",
         "axios": "^1.8.4",
-        "dotenv": "^16.5.0",
-        "express": "^5.1.0"
+        "dotenv": "^16.5.0"
       },
       "devDependencies": {
-        "@types/express": "^5.0.1",
         "@types/node": "^22.14.1",
         "@typescript-eslint/eslint-plugin": "^8.30.1",
         "@typescript-eslint/parser": "^8.30.1",
@@ -1050,70 +1048,16 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "dev": true
     },
-    "node_modules/@types/body-parser": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
-      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
-      "dev": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/connect": {
-      "version": "3.4.38",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
-      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/estree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.7.tgz",
       "integrity": "sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==",
       "dev": true
     },
-    "node_modules/@types/express": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.1.tgz",
-      "integrity": "sha512-UZUw8vjpWFXuDnjFTh7/5c2TWDlQqeXHi6hcN7F2XSVT5P+WmUnnbFS3KA6Jnc6IsEqI2qCVu2bK0R0J4A8ZQQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^5.0.0",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/@types/express-serve-static-core": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.6.tgz",
-      "integrity": "sha512-3xhRnjJPkULekpSzgtoNYYcTWgEZkp4myc+Saevii5JPnHNvHMRlBSHDbs7Bh1iPPoVTERHEZXyhyLbMEsExsA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
-      }
-    },
-    "node_modules/@types/http-errors": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
-      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
-      "dev": true
-    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
-    },
-    "node_modules/@types/mime": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
-      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
       "dev": true
     },
     "node_modules/@types/node": {
@@ -1123,39 +1067,6 @@
       "dev": true,
       "dependencies": {
         "undici-types": "~6.21.0"
-      }
-    },
-    "node_modules/@types/qs": {
-      "version": "6.9.18",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
-      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
-      "dev": true
-    },
-    "node_modules/@types/range-parser": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
-      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
-      "dev": true
-    },
-    "node_modules/@types/send": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
-      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
-      "dev": true,
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/serve-static": {
-      "version": "1.15.7",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
-      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
-      "dev": true,
-      "dependencies": {
-        "@types/http-errors": "*",
-        "@types/node": "*",
-        "@types/send": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@types/express": "^5.0.1",
     "@types/node": "^22.14.1",
     "@typescript-eslint/eslint-plugin": "^8.30.1",
     "@typescript-eslint/parser": "^8.30.1",
@@ -37,7 +36,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.9.0",
     "axios": "^1.8.4",
-    "dotenv": "^16.5.0",
-    "express": "^5.1.0"
+    "dotenv": "^16.5.0"
   }
 }

--- a/src/server/config/hotelConstants.ts
+++ b/src/server/config/hotelConstants.ts
@@ -1,0 +1,53 @@
+import { HotelChain } from '../../types/index.js';
+
+/**
+ * デフォルト設定値
+ */
+export const DEFAULT_LATITUDE = 35.6994856; // 東京本社座標
+export const DEFAULT_LONGITUDE = 139.7532791; // 東京本社座標
+export const DEFAULT_RADIUS_KM = 2;
+export const DEFAULT_MAX_PRICE = 15000; // デフォルトの1泊あたりの上限金額
+
+/**
+ * 優先ホテルチェーンの定義（上位5チェーン）
+ */
+export const PREFERRED_HOTEL_CHAINS: HotelChain[] = [
+  {
+    name: 'ルートインホテルズ',
+    keywords: ['ルートイン', 'ROUTE-INN', 'ルート・イン', 'ROUTEINN'],
+    priority: 1,
+  },
+  {
+    name: '東横INN',
+    keywords: ['東横イン', '東横INN', 'TOYOKO INN', 'TOYOKO-INN'],
+    priority: 2,
+  },
+  {
+    name: 'アパホテルズ&リゾーツ',
+    keywords: ['アパホテル', 'APA HOTEL', 'アパ・ホテル', 'アパヴィラ'],
+    priority: 3,
+  },
+  {
+    name: 'スーパーホテル',
+    keywords: ['スーパーホテル', 'SUPER HOTEL', 'スーパー・ホテル', 'スーパーホテルLohas'],
+    priority: 4,
+  },
+  {
+    name: 'リブマックスホテルズ&リゾーツ',
+    keywords: ['リブマックス', 'LIBEMAX', 'リブ・マックス', 'リブマックスリゾート'],
+    priority: 5,
+  },
+];
+
+/**
+ * 除外するホテルタイプのキーワード
+ */
+export const EXCLUDED_HOTEL_TYPES = [
+  'ドミトリー',
+  'カプセル',
+  'カプセルホテル',
+  '簡易宿泊',
+  'ゲストハウス',
+  'ホステル',
+  'バックパッカー',
+];

--- a/src/server/tools/getHotelsTool.test.ts
+++ b/src/server/tools/getHotelsTool.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axios from 'axios';
 import { getHotelsTool } from './getHotelsTool';
 import { RakutenApiResponse } from '../../types/index.js';
+import { DEFAULT_MAX_PRICE } from '../config/hotelConstants.js';
 
 vi.mock('axios');
 interface MockedAxios {
@@ -175,6 +176,191 @@ const mockApiResponseData: RakutenApiResponse = {
   ],
 };
 
+// 除外ホテルタイプのテスト用データ
+const excludedHotelMockData: RakutenApiResponse = {
+  pagingInfo: {
+    recordCount: 1,
+    pageCount: 1,
+    page: 1,
+    first: 1,
+    last: 1,
+  },
+  hotels: [
+    [
+      {
+        hotelBasicInfo: {
+          hotelNo: 100003,
+          hotelName: 'テストカプセルホテル',
+          hotelInformationUrl: 'https://example.com/hotel/100003',
+          planListUrl: 'https://example.com/hotel/100003/plans',
+          dpPlanListUrl: 'https://example.com/hotel/100003/dp_plans',
+          reviewUrl: 'https://example.com/hotel/100003/reviews',
+          hotelKanaName: 'てすとかぷせるほてる',
+          hotelSpecial: 'リーズナブルなカプセルホテル。ビジネスマンに人気です。',
+          hotelMinCharge: 3000,
+          latitude: 35.68,
+          longitude: 139.77,
+          postalCode: '100-0001',
+          address1: '東京都',
+          address2: '千代田区2-2-2',
+          telephoneNo: '03-1234-5678',
+          faxNo: '03-1234-5679',
+          access: '東京駅より徒歩8分',
+          parkingInformation: '駐車場なし',
+          nearestStation: '東京',
+          hotelImageUrl: 'https://example.com/images/hotel/100003.jpg',
+          hotelThumbnailUrl: 'https://example.com/images/hotel/thumb/100003.jpg',
+          roomImageUrl: 'https://example.com/images/room/100003.jpg',
+          roomThumbnailUrl: 'https://example.com/images/room/thumb/100003.jpg',
+          hotelMapImageUrl: 'https://example.com/images/map/100003.gif',
+          reviewCount: 500,
+          reviewAverage: 3.8,
+          userReview: 'コスパが良いです。',
+        },
+      },
+      {
+        roomInfo: [
+          {
+            roomBasicInfo: {
+              roomClass: 'cap',
+              roomName: 'カプセルルーム',
+              planId: 5000004,
+              planName: '【素泊まり】カプセルプラン',
+              pointRate: 1,
+              withDinnerFlag: 0,
+              dinnerSelectFlag: 0,
+              withBreakfastFlag: 0,
+              breakfastSelectFlag: 0,
+              payment: '1',
+              reserveUrl: 'https://example.com/reserve/100003/cap/5000004',
+              salesformFlag: 0,
+            },
+          },
+        ],
+      },
+    ],
+  ],
+};
+
+// 優先ホテルチェーンのテスト用データ
+const preferredChainMockData: RakutenApiResponse = {
+  pagingInfo: {
+    recordCount: 2,
+    pageCount: 1,
+    page: 1,
+    first: 1,
+    last: 2,
+  },
+  hotels: [
+    [
+      {
+        hotelBasicInfo: {
+          hotelNo: 100004,
+          hotelName: 'ルートイン東京',
+          hotelInformationUrl: 'https://example.com/hotel/100004',
+          planListUrl: 'https://example.com/hotel/100004/plans',
+          dpPlanListUrl: 'https://example.com/hotel/100004/dp_plans',
+          reviewUrl: 'https://example.com/hotel/100004/reviews',
+          hotelKanaName: 'るーといんとうきょう',
+          hotelSpecial: 'ビジネスホテルの定番。朝食無料サービス。',
+          hotelMinCharge: 6000,
+          latitude: 35.69,
+          longitude: 139.76,
+          postalCode: '100-0001',
+          address1: '東京都',
+          address2: '千代田区3-3-3',
+          telephoneNo: '03-1234-5678',
+          faxNo: '03-1234-5679',
+          access: '東京駅より徒歩10分',
+          parkingInformation: '有料駐車場あり',
+          nearestStation: '東京',
+          hotelImageUrl: 'https://example.com/images/hotel/100004.jpg',
+          hotelThumbnailUrl: 'https://example.com/images/hotel/thumb/100004.jpg',
+          roomImageUrl: 'https://example.com/images/room/100004.jpg',
+          roomThumbnailUrl: 'https://example.com/images/room/thumb/100004.jpg',
+          hotelMapImageUrl: 'https://example.com/images/map/100004.gif',
+          reviewCount: 800,
+          reviewAverage: 4.0,
+          userReview: '朝食が美味しいです。',
+        },
+      },
+      {
+        roomInfo: [
+          {
+            roomBasicInfo: {
+              roomClass: 'sgl',
+              roomName: 'シングルルーム',
+              planId: 5000005,
+              planName: '【朝食付き】ビジネスプラン',
+              pointRate: 1,
+              withDinnerFlag: 0,
+              dinnerSelectFlag: 0,
+              withBreakfastFlag: 1,
+              breakfastSelectFlag: 0,
+              payment: '1',
+              reserveUrl: 'https://example.com/reserve/100004/sgl/5000005',
+              salesformFlag: 0,
+            },
+          },
+        ],
+      },
+    ],
+    [
+      {
+        hotelBasicInfo: {
+          hotelNo: 100005,
+          hotelName: 'テストホテル新宿',
+          hotelInformationUrl: 'https://example.com/hotel/100005',
+          planListUrl: 'https://example.com/hotel/100005/plans',
+          dpPlanListUrl: 'https://example.com/hotel/100005/dp_plans',
+          reviewUrl: 'https://example.com/hotel/100005/reviews',
+          hotelKanaName: 'てすとほてるしんじゅく',
+          hotelSpecial: '新宿駅から徒歩5分。ビジネスにも観光にも便利。',
+          hotelMinCharge: 9000,
+          latitude: 35.69,
+          longitude: 139.7,
+          postalCode: '160-0001',
+          address1: '東京都',
+          address2: '新宿区1-1-1',
+          telephoneNo: '03-1234-5678',
+          faxNo: '03-1234-5679',
+          access: '新宿駅より徒歩5分',
+          parkingInformation: '有料駐車場あり',
+          nearestStation: '新宿',
+          hotelImageUrl: 'https://example.com/images/hotel/100005.jpg',
+          hotelThumbnailUrl: 'https://example.com/images/hotel/thumb/100005.jpg',
+          roomImageUrl: 'https://example.com/images/room/100005.jpg',
+          roomThumbnailUrl: 'https://example.com/images/room/thumb/100005.jpg',
+          hotelMapImageUrl: 'https://example.com/images/map/100005.gif',
+          reviewCount: 700,
+          reviewAverage: 4.1,
+          userReview: '立地が良いです。',
+        },
+      },
+      {
+        roomInfo: [
+          {
+            roomBasicInfo: {
+              roomClass: 'sgl',
+              roomName: 'シングルルーム',
+              planId: 5000006,
+              planName: '【素泊まり】スタンダードプラン',
+              pointRate: 1,
+              withDinnerFlag: 0,
+              dinnerSelectFlag: 0,
+              withBreakfastFlag: 0,
+              breakfastSelectFlag: 0,
+              payment: '1',
+              reserveUrl: 'https://example.com/reserve/100005/sgl/5000006',
+              salesformFlag: 0,
+            },
+          },
+        ],
+      },
+    ],
+  ],
+};
+
 describe('getHotelsTool', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -308,5 +494,83 @@ describe('getHotelsTool', () => {
 
     const result = await getHotelsTool.handler(request);
     expect(result).toEqual({ error: 'APIリクエストに失敗しました' });
+  });
+
+  it('maxPriceパラメーターが指定されている場合、それを使用すること', async () => {
+    const customMaxPrice = 10000;
+    const mockApiResponse = {
+      data: mockApiResponseData,
+    };
+
+    mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
+
+    const request = {
+      parameters: {
+        checkIn: '2023-12-01',
+        checkOut: '2023-12-02',
+        maxPrice: customMaxPrice,
+      },
+    };
+
+    const result = await getHotelsTool.handler(request);
+
+    // 金額上限でフィルタリングされていることを確認
+    // モックデータでは、テストホテル東京の最安料金は8000円、テストホテル大阪の最安料金は7000円
+    // どちらも10000円以下なので、両方とも結果に含まれるはず
+    expect(result.result?.hotels.length).toBe(2);
+  });
+
+  it('maxPriceパラメーターが無効な場合、エラーを返すこと', async () => {
+    const request = {
+      parameters: {
+        checkIn: '2023-12-01',
+        checkOut: '2023-12-02',
+        maxPrice: -1000, // 負の値は無効
+      },
+    };
+
+    const result = await getHotelsTool.handler(request);
+    expect(result).toEqual({ error: '上限金額は0より大きい値で指定してください。' });
+  });
+
+  it('除外ホテルタイプのフィルタリングが機能すること', async () => {
+    const mockApiResponse = {
+      data: excludedHotelMockData,
+    };
+
+    mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
+
+    const request = {
+      parameters: {
+        checkIn: '2023-12-01',
+        checkOut: '2023-12-02',
+      },
+    };
+
+    const result = await getHotelsTool.handler(request);
+
+    // カプセルホテルは除外されるため、結果は0件になるはず
+    expect(result.result?.hotels.length).toBe(0);
+  });
+
+  it('優先ホテルチェーンが優先されること', async () => {
+    const mockApiResponse = {
+      data: preferredChainMockData,
+    };
+
+    mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
+
+    const request = {
+      parameters: {
+        checkIn: '2023-12-01',
+        checkOut: '2023-12-02',
+      },
+    };
+
+    const result = await getHotelsTool.handler(request);
+
+    // ルートインホテルが優先されるため、最初のホテルはルートインになるはず
+    expect(result.result?.hotels.length).toBe(2);
+    expect(result.result?.hotels[0].hotelBasicInfo.hotelName).toBe('ルートイン東京');
   });
 });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,6 +4,21 @@ export interface HotelQueryParams {
   latitude?: number;
   longitude?: number;
   radiusKm?: number;
+  maxPrice?: number; // 1泊あたりの最大金額（デフォルト: 15000円）
+}
+
+// ホテルチェーン情報
+export interface HotelChain {
+  name: string; // チェーン名
+  keywords: string[]; // 判定用キーワード
+  priority: number; // 優先度（数値が小さいほど優先）
+}
+
+// 部屋タイプ情報
+export interface RoomTypePreference {
+  type: string; // 部屋タイプ識別子
+  keywords: string[]; // 判定用キーワード
+  priority: number; // 優先度（数値が小さいほど優先）
 }
 
 // ホテルの基本情報

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,10 +9,9 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['express', '@modelcontextprotocol/sdk', 'axios', 'dotenv'],
+      external: ['@modelcontextprotocol/sdk', 'axios', 'dotenv'],
       output: {
         globals: {
-          express: 'express',
           '@modelcontextprotocol/sdk': 'mcpSdk',
           axios: 'axios',
           dotenv: 'dotenv',


### PR DESCRIPTION
## 変更内容

1. 金額上限パラメーターの追加
   - \maxPrice\パラメーターを追加し、デフォルト値を15000円に設定
   - 金額上限でのフィルタリング処理を実装

2. 座標からの距離順ソート
   - ハーバーサイン公式を使用した距離計算関数を実装
   - 検索座標からの距離でホテルをソート

3. 除外ホテルタイプの設定
   - ドミトリー、カプセル、簡易宿泊所などを除外するフィルタリング処理を実装

4. 優先ホテルチェーンの設定
   - 上位5チェーン（ルートイン、東横INN、アパホテル、スーパーホテル、リブマックス）を優先するソート処理を実装

5. 設定の分離
   - 定数を\src/server/config/hotelConstants.ts\に切り出し
   - 計算処理は\getHotelsTool.ts\に統合

6. 説明文の修正
   - デフォルト座標の説明を「東京」から「東京本社座標」に修正

7. テストの追加
   - 金額上限パラメーターのテスト
   - 優先ホテルチェーンのソートテスト
   - 除外ホテルタイプのフィルタリングテスト